### PR TITLE
Use ALSA default capture device

### DIFF
--- a/Examples/.asoundrc
+++ b/Examples/.asoundrc
@@ -1,0 +1,43 @@
+############################################################
+# 1) Mixeur logiciel pour le playback sur le Robot HAT
+pcm.dmixer {
+    type     dmix
+    ipc_key  1024
+    slave {
+        pcm         "hw:0,0"    # HAT = card 0, device 0
+        rate        48000       # fréquence native du DAC
+        period_size 1024
+        buffer_size 4096
+    }
+}
+
+############################################################
+# 2) Plug pour la capture USB Mic
+#    convertit 16 kHz → 48 kHz pour le hardware
+pcm.capplug {
+    type plug
+    slave {
+        pcm    "hw:1,0"    # Micro USB = card 1, device 0
+        rate   48000       # fréquence native du mic
+    }
+}
+
+############################################################
+# 3) Périphérique asymétrique (playback vs capture)
+pcm.asym {
+    type          asym
+    playback.pcm  "dmixer"
+    capture.pcm   "capplug"
+}
+
+############################################################
+# 4) Définit 'default' sur cet asynchrone avec resampling
+pcm.!default {
+    type     plug
+    slave.pcm "asym"
+}
+
+ctl.!default {
+    type hw
+    card 0            # contrôle global sur la carte 0 (HAT)
+}

--- a/Project.md
+++ b/Project.md
@@ -67,7 +67,7 @@ python utils\play_json.py reply.json  # writes response.mp3 & plays it
 * **Audio Processing** – High-pass filter, normalization, SNR calculation
 * **Smart VAD** – Multi-criteria detection with confidence scoring
 * **Auto-calibration** – Adapts to ambient noise with percentile-based thresholds
-* **Device Selection** – Automatically finds the best microphone
+* **Audio Input** – Uses ALSA's default capture device (override with `--input-device`)
 * **POST** to `/ask` with token header and normalized audio
 * **Play** the returned MP3 via robot_hat Music API
 * **Statistics** – Real-time SNR monitoring and session stats

--- a/Readme.md
+++ b/Readme.md
@@ -74,7 +74,7 @@ User → PiCar-X Mic → (client.py) → Local PC (ask_server.py + Ollama) → L
 
 1. Enable microphone and speaker support.
 1.1.
-Create /root/.asoundrc or /etc/asound.conf with:
+Create `/root/.asoundrc` or `/etc/asound.conf` with (see `Examples/.asoundrc`):
 ############################################################
 # 1) Mixeur logiciel pour le playback sur le Robot HAT
 pcm.dmixer {
@@ -131,7 +131,13 @@ ctl.!default {
 
    ```bash
    python client.py
+   # Optional: specify an alternate microphone index
+   python client.py --input-device 1
    ```
+
+   The client uses the capture device defined in your `.asoundrc` by default.
+   See `Examples/.asoundrc` for a ready-to-use configuration. Use
+   `--input-device` to override the PyAudio index when required.
 
 ---
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -408,11 +408,11 @@ class Client:
                 self.my_car = None # Ensure my_car is None if init fails
         
     def _setup_audio_input(self):
-        """Configure le flux audio avec sélection automatique du micro"""
+        """Configure le flux audio en utilisant le micro par défaut ou un périphérique spécifié"""
         try:
-            # Trouver le meilleur microphone
-            device_index = DeviceSelector.find_best_microphone(self.pa)
-            
+            # Utilise le périphérique d'entrée défini par l'utilisateur ou le défaut ALSA
+            device_index = self.args.input_device
+
             self.stream = self.pa.open(
                 rate=SR,
                 channels=1,
@@ -786,8 +786,10 @@ if __name__ == "__main__":
         print(f"[WARN] Failed to run speaker enable command: {e}. Sound might not work.")
 
     parser = argparse.ArgumentParser(description="PiCar-X Voice Assistant Client")
-    parser.add_argument("--with-movements", action="store_true", 
+    parser.add_argument("--with-movements", action="store_true",
                         help="Enable robot movements and actions in response to commands.")
+    parser.add_argument("--input-device", type=int, default=None,
+                        help="PyAudio input device index. Uses ALSA default when omitted.")
     args = parser.parse_args()
 
     print("🤖 PiCar-X Voice Assistant - Version optimisée avec réduction de bruit")


### PR DESCRIPTION
## Summary
- open PyAudio with the default device unless overridden by command line
- add `--input-device` argument for manual microphone selection
- document ALSA defaults and sample `.asoundrc` file

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'piper')*

------
https://chatgpt.com/codex/tasks/task_e_68450cf2a9d4832c87e45e721ad47ab3